### PR TITLE
Fix prestige confirmations and other story flags

### DIFF
--- a/actionList.js
+++ b/actionList.js
@@ -4934,9 +4934,8 @@ Action.Mercantilism = new Action("Mercantilism", {
     },
     finish() {
         handleSkillExp(this.skills);
-        view.requestUpdate("adjustManaCost", "Buy Mana Z1");
-        view.requestUpdate("adjustManaCost", "Buy Mana Z3");
-        view.requestUpdate("adjustManaCost", "Buy Mana Z5");
+        //Needed for Mercantilism levelup
+        view.requestUpdate("adjustGoldCosts");
     },
 });
 
@@ -7066,6 +7065,8 @@ Action.Invest = new Action("Invest", {
     },
     finish() {
         handleSkillExp(this.skills);
+        //Needed for Mercantilism levelup
+        view.requestUpdate("adjustGoldCosts");
 
         //Looks like something (maybe very high accelerations?) can give you a gold value of NaN.  If so, don't corrupt
         //the save file
@@ -7120,6 +7121,9 @@ Action.CollectInterest = new Action("Collect Interest", {
     },
     finish() {
         handleSkillExp(this.skills);
+        //Needed for Mercantilism levelup
+        view.requestUpdate("adjustGoldCosts");
+
         let interestGold = Math.floor(goldInvested * .001);
         addResource("gold", interestGold);
         setStoryFlag("interestCollected");

--- a/actionList.js
+++ b/actionList.js
@@ -3110,14 +3110,14 @@ Action.AdventureGuild = new MultipartAction("Adventure Guild", {
                 Math.sqrt(1 + totalCompletions / 1000);
     },
     loopsFinished() {
-        if (curAdvGuildSegment >= 0) setStoryFlag("advGuildRankEReached");
-        if (curAdvGuildSegment >= 3) setStoryFlag("advGuildRankDReached");
-        if (curAdvGuildSegment >= 6) setStoryFlag("advGuildRankCReached");
-        if (curAdvGuildSegment >= 9) setStoryFlag("advGuildRankBReached");
-        if (curAdvGuildSegment >= 12) setStoryFlag("advGuildRankAReached");
-        if (curAdvGuildSegment >= 15) setStoryFlag("advGuildRankSReached");
-        if (curAdvGuildSegment >= 27) setStoryFlag("advGuildRankUReached");
-        if (curAdvGuildSegment >= 39) setStoryFlag("advGuildRankGodlikeReached");
+        if (curAdvGuildSegment >= 3) setStoryFlag("advGuildRankEReached");
+        if (curAdvGuildSegment >= 6) setStoryFlag("advGuildRankDReached");
+        if (curAdvGuildSegment >= 9) setStoryFlag("advGuildRankCReached");
+        if (curAdvGuildSegment >= 12) setStoryFlag("advGuildRankBReached");
+        if (curAdvGuildSegment >= 15) setStoryFlag("advGuildRankAReached");
+        if (curAdvGuildSegment >= 18) setStoryFlag("advGuildRankSReached");
+        if (curAdvGuildSegment >= 30) setStoryFlag("advGuildRankUReached");
+        if (curAdvGuildSegment >= 42) setStoryFlag("advGuildRankGodlikeReached");
     },
     segmentFinished() {
         curAdvGuildSegment++;
@@ -3327,14 +3327,14 @@ Action.CraftingGuild = new MultipartAction("Crafting Guild", {
                 Math.sqrt(1 + totalCompletions / 1000);
     },
     loopsFinished() {
-        if (curCraftGuildSegment >= 0) setStoryFlag("craftGuildRankEReached");
-        if (curCraftGuildSegment >= 3) setStoryFlag("craftGuildRankDReached");
-        if (curCraftGuildSegment >= 6) setStoryFlag("craftGuildRankCReached");
-        if (curCraftGuildSegment >= 9) setStoryFlag("craftGuildRankBReached");
-        if (curCraftGuildSegment >= 12) setStoryFlag("craftGuildRankAReached");
-        if (curCraftGuildSegment >= 15) setStoryFlag("craftGuildRankSReached");
-        if (curCraftGuildSegment >= 27) setStoryFlag("craftGuildRankUReached");
-        if (curCraftGuildSegment >= 39) setStoryFlag("craftGuildRankGodlikeReached");
+        if (curCraftGuildSegment >= 3) setStoryFlag("craftGuildRankEReached");
+        if (curCraftGuildSegment >= 6) setStoryFlag("craftGuildRankDReached");
+        if (curCraftGuildSegment >= 9) setStoryFlag("craftGuildRankCReached");
+        if (curCraftGuildSegment >= 12) setStoryFlag("craftGuildRankBReached");
+        if (curCraftGuildSegment >= 15) setStoryFlag("craftGuildRankAReached");
+        if (curCraftGuildSegment >= 18) setStoryFlag("craftGuildRankSReached");
+        if (curCraftGuildSegment >= 30) setStoryFlag("craftGuildRankUReached");
+        if (curCraftGuildSegment >= 42) setStoryFlag("craftGuildRankGodlikeReached");
     },
     segmentFinished() {
         curCraftGuildSegment++;
@@ -5474,16 +5474,16 @@ Action.FightFrostGiants = new MultipartAction("Fight Frost Giants", {
     },
     segmentFinished() {
         curFightFrostGiantsSegment++;
-        if (curFightFrostGiantsSegment >= 6) setStoryFlag("giantGuildRankEReached");
-        if (curFightFrostGiantsSegment >= 12) setStoryFlag("giantGuildRankDReached");
-        if (curFightFrostGiantsSegment >= 18) setStoryFlag("giantGuildRankCReached");
-        if (curFightFrostGiantsSegment >= 24) setStoryFlag("giantGuildRankBReached");
-        if (curFightFrostGiantsSegment >= 30) setStoryFlag("giantGuildRankAReached");
-        if (curFightFrostGiantsSegment >= 36) setStoryFlag("giantGuildRankSReached");
-        if (curFightFrostGiantsSegment >= 42) setStoryFlag("giantGuildRankSSReached");
-        if (curFightFrostGiantsSegment >= 48) setStoryFlag("giantGuildRankSSSReached");
-        if (curFightFrostGiantsSegment >= 54) setStoryFlag("giantGuildRankUReached");
-        if (curFightFrostGiantsSegment >= 60) setStoryFlag("giantGuildRankGodlikeReached");
+        if (curFightFrostGiantsSegment >= 3) setStoryFlag("giantGuildRankEReached");
+        if (curFightFrostGiantsSegment >= 9) setStoryFlag("giantGuildRankDReached");
+        if (curFightFrostGiantsSegment >= 15) setStoryFlag("giantGuildRankCReached");
+        if (curFightFrostGiantsSegment >= 21) setStoryFlag("giantGuildRankBReached");
+        if (curFightFrostGiantsSegment >= 27) setStoryFlag("giantGuildRankAReached");
+        if (curFightFrostGiantsSegment >= 33) setStoryFlag("giantGuildRankSReached");
+        if (curFightFrostGiantsSegment >= 39) setStoryFlag("giantGuildRankSSReached");
+        if (curFightFrostGiantsSegment >= 45) setStoryFlag("giantGuildRankSSSReached");
+        if (curFightFrostGiantsSegment >= 51) setStoryFlag("giantGuildRankUReached");
+        if (curFightFrostGiantsSegment >= 57) setStoryFlag("giantGuildRankGodlikeReached");
     },
     getPartName() {
         return `${getFrostGiantsRank().name}`;
@@ -6182,15 +6182,15 @@ Action.FightJungleMonsters = new MultipartAction("Fight Jungle Monsters", {
         //I.e., the sloth fight is segments 6, 7 and 8, so the unlock
         //happens when the 8th segment is done and the current segment
         //is 9 or more.
-        if (curFightJungleMonstersSegment > 8) setStoryFlag("monsterGuildRankDReached");
-        if (curFightJungleMonstersSegment > 14) setStoryFlag("monsterGuildRankCReached");
-        if (curFightJungleMonstersSegment > 20) setStoryFlag("monsterGuildRankBReached");
-        if (curFightJungleMonstersSegment > 26) setStoryFlag("monsterGuildRankAReached");
-        if (curFightJungleMonstersSegment > 32) setStoryFlag("monsterGuildRankSReached");
-        if (curFightJungleMonstersSegment > 38) setStoryFlag("monsterGuildRankSSReached");
-        if (curFightJungleMonstersSegment > 44) setStoryFlag("monsterGuildRankSSSReached");
-        if (curFightJungleMonstersSegment > 50) setStoryFlag("monsterGuildRankUReached");
-        if (curFightJungleMonstersSegment > 56) setStoryFlag("monsterGuildRankGodlikeReached");
+        if (curFightJungleMonstersSegment >= 9) setStoryFlag("monsterGuildRankDReached");
+        if (curFightJungleMonstersSegment >= 15) setStoryFlag("monsterGuildRankCReached");
+        if (curFightJungleMonstersSegment >= 21) setStoryFlag("monsterGuildRankBReached");
+        if (curFightJungleMonstersSegment >= 27) setStoryFlag("monsterGuildRankAReached");
+        if (curFightJungleMonstersSegment >= 33) setStoryFlag("monsterGuildRankSReached");
+        if (curFightJungleMonstersSegment >= 39) setStoryFlag("monsterGuildRankSSReached");
+        if (curFightJungleMonstersSegment >= 45) setStoryFlag("monsterGuildRankSSSReached");
+        if (curFightJungleMonstersSegment >= 51) setStoryFlag("monsterGuildRankUReached");
+        if (curFightJungleMonstersSegment >= 57) setStoryFlag("monsterGuildRankGodlikeReached");
         // Additional thing?
     },
     getPartName() {

--- a/actionList.js
+++ b/actionList.js
@@ -5635,6 +5635,7 @@ Action.GreatFeast = new MultipartAction("Great Feast", {
         return Math.ceil(5000 * (getBuffLevel("Feast") + 1) * getSkillBonus("Gluttony"));
     },
     finish() {
+        setStoryFlag("feastAttempted")
         view.requestUpdate("updateBuff", "Feast");
     },
 });
@@ -6426,6 +6427,8 @@ Action.Escape = new Action("Escape", {
         unlockTown(7);
     },
     story(completed) {
+        //FIXME: This will (unfortunately) give the story completion for creating the looping potion, even
+        //if the player didn't, because completing story N will also complete all stories less than N.
         unlockGlobalStory(10);
     },
 });
@@ -7318,11 +7321,14 @@ Action.ImbueSoul = new MultipartAction("Imbue Soul", {
     storyReqs(storyNum) {
         switch(storyNum) {
             case 1: return storyFlags.soulInfusionAttempted;
-            case 2: return buffs["Imbuement3"].amt > 0;
-            case 3: return buffs["Imbuement3"].amt > 6;
-            case 4: return buffs["Imbuement"].amt > 499
-                        && buffs["Imbuement2"].amt > 499
-                        && buffs["Imbuement3"].amt > 6;
+            //Protect these with a check for soulInfusionAttempted, so they don't "finish" instantly
+            //on prestige.
+            case 2: return storyFlags.soulInfusionAttempted && buffs["Imbuement3"].amt > 0;
+            case 3: return storyFlags.soulInfusionAttempted && buffs["Imbuement3"].amt > 6;
+            case 4: return storyFlags.soulInfusionAttempted &&
+                        buffs["Imbuement"].amt > 499 &&
+                        buffs["Imbuement2"].amt > 499 &&
+                        buffs["Imbuement3"].amt > 6;
         }
     },
     stats: {
@@ -7369,6 +7375,7 @@ Action.ImbueSoul = new MultipartAction("Imbue Soul", {
         return getBuffLevel("Imbuement") > 499 && getBuffLevel("Imbuement2") > 499;
     },
     finish() {
+        setStoryFlag("soulInfusionAttempted")
         view.requestUpdate("updateBuff", "Imbuement3");
         capAllTraining();
         adjustTrainingExpMult();

--- a/actionList.js
+++ b/actionList.js
@@ -6284,8 +6284,8 @@ Action.RescueSurvivors = new MultipartAction("Rescue Survivors", {
     loopsFinished(loopCounter = towns[6].RescueLoopCounter) {
         addResource("reputation", 4);
         setStoryFlag("survivorRescued");
-        if (loopCounter >= 6) setStoryFlag("rescued6Survivors");
-        if (loopCounter >= 20) setStoryFlag("rescued20Survivors");
+        if (loopCounter >= 6*3) setStoryFlag("rescued6Survivors");
+        if (loopCounter >= 20*3) setStoryFlag("rescued20Survivors");
     },
     getPartName(loopCounter = towns[6].RescueLoopCounter) {
         return `${_txt(`actions>${getXMLName(this.name)}>label_part`)} ${numberToWords(Math.floor((loopCounter + 0.0001) / this.segments + 1))}`;

--- a/actionList.js
+++ b/actionList.js
@@ -7066,9 +7066,17 @@ Action.Invest = new Action("Invest", {
     },
     finish() {
         handleSkillExp(this.skills);
-        goldInvested += resources.gold;
-        if (goldInvested > 999999999999) goldInvested = 999999999999;
-        resetResource("gold");
+
+        //Looks like something (maybe very high accelerations?) can give you a gold value of NaN.  If so, don't corrupt
+        //the save file
+        if (!isNaN(resources.gold))
+        {
+            goldInvested += resources.gold;
+            if (goldInvested > 999999999999) goldInvested = 999999999999;
+
+            //Don't reset the gold value if it's NaN.  This should make it a bit easier to see what went wrong.
+            resetResource("gold");
+        }
         if (storyFlags.investedOne) setStoryFlag("investedTwo");
         setStoryFlag("investedOne");
         view.requestUpdate("updateActionTooltips", null);

--- a/actionList.js
+++ b/actionList.js
@@ -6460,7 +6460,7 @@ Action.OpenPortal = new Action("Open Portal", {
         return getExploreProgress() > 50;
     },
     unlocked() {
-        return getExploreProgress() >= 75;
+        return getExploreProgress() >= 75 && getSkillLevel("Restoration") >= 1000;
     },
     canStart() {
         return getSkillLevel("Restoration") >= 1000;

--- a/actionList.js
+++ b/actionList.js
@@ -7070,7 +7070,7 @@ Action.Invest = new Action("Invest", {
 
         //Looks like something (maybe very high accelerations?) can give you a gold value of NaN.  If so, don't corrupt
         //the save file
-        if (!isNaN(resources.gold))
+        if (isFinite(resources.gold))
         {
             goldInvested += resources.gold;
             if (goldInvested > 999999999999) goldInvested = 999999999999;

--- a/actions.js
+++ b/actions.js
@@ -728,7 +728,13 @@ function markActionsComplete(loopCompletedActions) {
 function actionStory(loopCompletedActions) {
     loopCompletedActions.forEach(action => {
         let completed = action.loops - action.loopsLeft;
-        if (action.story !== undefined) action.story(completed);
+        //Test for completed, because all of the actions in .story(completed) assume it was successfully
+        //completed.  Without this we advance the story by putting an action in the list rather than
+        // completing it.  We should really have a hook for failure as well.
+        if (completed > 0 && action.story !== undefined)
+        {
+            action.story(completed);
+        }
     });
 }
 

--- a/actions.js
+++ b/actions.js
@@ -154,6 +154,10 @@ class Actions {
                 while (curProgress >= loopCost(segment)) {
                     curProgress -= loopCost(segment);
                     // segment finished
+                    if (curAction.segmentFinished) {
+                        curAction.segmentFinished();
+                        partUpdateRequired = true;
+                    }
                     if (segment === curAction.segments - 1) {
                         // part finished
                         if (curAction.name === "Dark Ritual" && towns[curAction.townNum][curAction.varName] >= 4000000) setStoryFlag("darkRitualThirdSegmentReached");
@@ -177,10 +181,6 @@ class Actions {
                             break manaLoop;
                         }
                         towns[curAction.townNum][curAction.varName] = curProgress;
-                    }
-                    if (curAction.segmentFinished) {
-                        curAction.segmentFinished();
-                        partUpdateRequired = true;
                     }
                     segment++;
                     manaLeftForCurrentSegment = Math.min(manaLeft, getMaxTicksForStat(curAction, curAction.loopStats[segment], false));

--- a/lang/en-EN/game.xml
+++ b/lang/en-EN/game.xml
@@ -1228,7 +1228,7 @@
         <spatiomancy>
             <label>Spatiomancy</label>
             <desc>Who knew bending reality to your will could be so useful!</desc>
-            <desc2><![CDATA[Mana Geyser and Mana Well are reduced to the original / (1 + level / 100).<br>
+            <desc2><![CDATA[Mana Geyser and Mana Well action cost are reduced to the original / (1 + level / 100).<br>
             Houses to build increased by 1% per level from 1 - 500.<br>
             The following actions are increased by 0.5% per level in their level range.<br>
             101-300 Locked houses<br>

--- a/lang/en-EN/game.xml
+++ b/lang/en-EN/game.xml
@@ -3268,8 +3268,8 @@
             <label>Open Portal</label>
             <tooltip><![CDATA[
             The Explorers' guild tells you of a secret grove within the Jungle, where the barrier between realms is weakest. With enough restoration skill, you might be able to open a rift back and leave the shadow realm. However, it seems quite a bit of time passes in the portal, and some merchants have closed up shop.<br>
-            Unlocked with 75% of the world surveyed.<br>
-            Travels to Forest Path.<br>Buy Mana actions can not be used for the rest of the current loop.<br>Requires 1000 Restoration.
+            Unlocked with 75% of the world surveyed, and 1000 Restoration.<br>
+            Travels to Forest Path.<br>Buy Mana actions can not be used for the rest of the current loop.
             ]]></tooltip>
             <story_1><![CDATA[<b>Portal opened:</b>⮀ Despite the Veil being thin in this place, you still have to push quite a bit to get through. Whether it is due to the Gods trying to keep the Shadow Realm from invading or the simple physics of inter-realm travel, you can feel the hunger from the Jungle grow quiet as you approach the rippling portal you just created and step through to the forest on the other side. Looking at the sky, you're surprised to find that night is falling now!]]></story_1>
         </open_portal>

--- a/lang/en-EN/game.xml
+++ b/lang/en-EN/game.xml
@@ -1228,7 +1228,7 @@
         <spatiomancy>
             <label>Spatiomancy</label>
             <desc>Who knew bending reality to your will could be so useful!</desc>
-            <desc2><![CDATA[Mana Geyser and Mana Well action cost are reduced to the original / (1 + level / 100).<br>
+            <desc2><![CDATA[The mana costs for the Mana Geyser and Mana Well actions are reduced to the original / (1 + level / 100).<br>
             Houses to build increased by 1% per level from 1 - 500.<br>
             The following actions are increased by 0.5% per level in their level range.<br>
             101-300 Locked houses<br>

--- a/prestige.js
+++ b/prestige.js
@@ -125,6 +125,14 @@ function prestigeWithNewValues(nextPrestigeValues, nextPrestigeBuffs) {
 
 function prestigeConfirmation() {
     save();
+
+    if (totals.actions === 0)
+    {
+        //This helps prevent repeated confirmations, and blowing away your backup when picking a second ability.
+        //If you have no actions, then there's nothing worth protecting.
+        return true;
+    }
+
     if (window.localStorage[defaultSaveName] && window.localStorage[defaultSaveName] !== "") {
         if (confirm(`Prestiging will reset all of your progress, but retain prestige points. Are you sure?`)) {
             for (const town of towns) {


### PR DESCRIPTION
- Fix actions advancing the story even when the action wasn't started
- Fix Imbuement3 story being completed on prestige before it's attempted.
- Fix Imbuement3 and Feast never giving the attempted message
- Fix when guild actions unlock
- Fix mana costs not updating when Mercantilism is leveled
- Fix unlock for Restoration shortcut
- Fix repeated confirmations when prestiging