### PR TITLE
Tweak some actions to make things visible sooner to help the player make informed choices

### DIFF
--- a/actionList.js
+++ b/actionList.js
@@ -2470,7 +2470,7 @@ Action.BirdWatching = new Action("Bird Watching", {
         return resources.glasses;
     },
     visible() {
-        return towns[1].getLevel("Flowers") >= 30;
+        return towns[1].getLevel("Flowers") >= 30 || towns[1].getLevel("Forest") >= 80;
     },
     unlocked() {
         return towns[1].getLevel("Flowers") >= 80;

--- a/actionList.js
+++ b/actionList.js
@@ -661,7 +661,7 @@ function RuinsAction(townNum) {
         },
         affectedBy: ["SurveyZ1"],
         visible() {
-            return towns[this.townNum].getLevel("Survey") >= 100;
+            return towns[this.townNum].getLevel("Survey") >= 80;
         },
         unlocked() {
             return towns[this.townNum].getLevel("Survey") >= 100;
@@ -1458,6 +1458,9 @@ Action.HealTheSick = new MultipartAction("Heal The Sick", {
             case 5:
                 // fail reputation req
                 return storyFlags.failedHeal;
+            case 7:
+                return getSkillLevel("Restoration") >= 1;
+            //Yes, this is out of order, because Restoration>=1 was added later
             case 6:
                 return getSkillLevel("Restoration") >= 50;
         }
@@ -2262,7 +2265,7 @@ Action.LearnAlchemy = new Action("Learn Alchemy", {
         return Math.ceil(5000 * (1 - towns[1].getLevel("Hermit") * 0.005));
     },
     visible() {
-        return towns[1].getLevel("Hermit") >= 10;
+        return towns[1].getLevel("Hermit") >= 1;
     },
     unlocked() {
         return towns[1].getLevel("Hermit") >= 40 && getSkillLevel("Magic") >= 60;
@@ -3244,8 +3247,12 @@ Action.LargeDungeon = new DungeonAction("Large Dungeon", 1, {
         return 6000;
     },
     canStart(loopCounter = towns[this.townNum].LDungeonLoopCounter) {
+        if (resources.teamMembers < 1 && resources.zombie < 1)
+        {
+            return false;
+        }
         const curFloor = Math.floor((loopCounter) / this.segments + 0.0000001);
-        return resources.teamMembers >= 1 && curFloor < dungeons[this.dungeonNum].length;
+        return curFloor < dungeons[this.dungeonNum].length;
     },
     loopCost(segment, loopCounter = towns[this.townNum].LDungeonLoopCounter) {
         return precision3(Math.pow(3, Math.floor((loopCounter + segment) / this.segments + 0.0000001)) * 5e5);
@@ -5946,10 +5953,10 @@ Action.TheSpire = new DungeonAction("The Spire", 2, {
         if (curFloor == dungeonFloors[this.dungeonNum]-1) setStoryFlag("clearedSpire");
     },
     visible() {
-        return towns[5].getLevel("Meander") >= 5;
+        return towns[5].getLevel("Meander") >= 3;
     },
     unlocked() {
-        return (getSkillLevel("Combat") + getSkillLevel("Magic")) >= 35;
+        return towns[5].getLevel("Meander") >= 5;
     },
     finish() {
         handleSkillExp(this.skills);
@@ -7149,7 +7156,7 @@ Action.Seminar = new Action("Seminar", {
         addResource("gold", -1000);
     },
     visible() {
-        return towns[this.townNum].getLevel("Survey") >= 100;
+        return towns[this.townNum].getLevel("Survey") >= 80;
     },
     unlocked() {
         return towns[this.townNum].getLevel("Survey") >= 100;

--- a/lang/en-EN/game.xml
+++ b/lang/en-EN/game.xml
@@ -1606,7 +1606,8 @@
             <label>Ruins</label>
             <label_done>Delved</label_done>
             <tooltip><![CDATA[
-            As you explore, you find ruins scattered among the trees. You better explore them, who knows what useful secrets they hide.
+            As you explore, you find ruins scattered among the trees. You better explore them, who knows what useful secrets they hide.<br>
+            Requires surveying 100% of the zone.
             ]]></tooltip>
             <story_1><![CDATA[<b>10% delved:</b>⮀ You decide to explore the ruins in the Forest and notice some weird looking rocks, wondering idly what they do.]]></story_1>
             <story_2><![CDATA[<b>50% delved:</b>⮀ After investigating these weird looking rocks you notice they are cubical and are heavy, looks like they are dusty from the time they have been sitting here.]]></story_2>
@@ -1616,7 +1617,8 @@
             <label>Ruins</label>
             <label_done>Delved</label_done>
             <tooltip><![CDATA[
-            As you explore, you find ruins scattered around the Mountain. You better explore them, who knows what useful secrets they hide.
+            As you explore, you find ruins scattered around the Mountain. You better explore them, who knows what useful secrets they hide.<br>
+            Requires surveying 100% of the zone.
             ]]></tooltip>
             <story_1><![CDATA[<b>10% delved:</b>⮀ You decide to explore the ruins around Mt. Olympus and notice the same cubical rocks as you found in the forest. You wonder what they were made for.]]></story_1>
             <story_2><![CDATA[<b>50% delved:</b>⮀ There is a stone with some writing, with your high intelligence you might be able to read this strange language.]]></story_2>
@@ -1626,7 +1628,8 @@
             <label>Ruins</label>
             <label_done>Delved</label_done>
             <tooltip><![CDATA[
-            As you explore, you find ruins scattered around the shadowy village. You better explore them, who knows what useful secrets they hide.
+            As you explore, you find ruins scattered around the shadowy village. You better explore them, who knows what useful secrets they hide.<br>
+            Requires surveying 100% of the zone.
             ]]></tooltip>
             <story_1><![CDATA[<b>10% delved:</b>⮀ You decide to explore the ruins of Startington and notice the same dusty cubical rocks as you found in the other ruins. You wonder what they do.]]></story_1>
             <story_2><![CDATA[<b>50% delved:</b>⮀ After deciphering the text on this stone block, You can see some writing on them. Sadly, much of the writing is too eroded to make out.]]></story_2>
@@ -1636,7 +1639,8 @@
             <label>Ruins</label>
             <label_done>Delved</label_done>
             <tooltip><![CDATA[
-            As you explore, you find ruins scattered around the dense jungle. You better explore them, who knows what useful secrets they hide.
+            As you explore, you find ruins scattered around the dense jungle. You better explore them, who knows what useful secrets they hide.<br>
+            Requires surveying 100% of the zone.
             ]]></tooltip>
             <story_1><![CDATA[<b>10% delved:</b>⮀ You decide to explore the ruins along the Jungle Path and notice yet again more of the same dusty and heavy cubical rocks. The mystery of the rocks endures...]]></story_1>
             <story_2><![CDATA[<b>50% delved:</b>⮀ During your ruin exploration, you find a weapon. Ancient, heavy and ornate. It takes some thinking, but you eventually recall a legend of a God wielding this particular weapon into battle.]]></story_2>
@@ -1905,7 +1909,8 @@
 			<story_3><![CDATA[<b>100 Patients healed:</b>⮀ You've healed some of these townsfolk so many times, you don't actually need to speak to them or examine them to find out what's wrong. You go through the same steps anyways, because good bedside manners are an integral part of earning respect as a healer.]]></story_3>
 			<story_4><![CDATA[<b>1000 Patients healed:</b>⮀ You never formally trained as a healer, but you've healed so many people that you're pretty much an expert now. Nothing can stop you, nothing can stump you, nothing can even slow you down! ...Except when they bring in a patient you haven't seen before. When that happens, it usually takes you a while to figure out what their problem is.]]></story_4>
 			<story_5><![CDATA[<b>Failed Action:</b>⮀ You're turned away at the door, the small healers home stating that they can't trust you to not poison the people inside or make the situation worse.]]></story_5>
-			<story_6><![CDATA[<b>50 Restoration:</b>⮀ You'd say it's like magic, but you were already using magic so instead it's like double-magic. The medics can't tell what you're doing, it's completely outside their paradigm: you simply touch the patient's forehead and, with a surge of energy, they're healed. You don't do it to boast, though. All you want is to help.]]></story_6>
+			<story_7><![CDATA[<b>1 Restoration:</b>⮀ You really want to try out your new Restoration magic, but so far your instructors back in Valhalla haven't let you it on a person yet.  Sure, any victems, err, paitents would be restored to their usual imperfect health at the end of the loop, but maybe a little more practice first wouldn't hurt either.]]></story_7>
+            <story_6><![CDATA[<b>50 Restoration:</b>⮀ You'd say it's like magic, but you were already using magic so instead it's like double-magic. The medics can't tell what you're doing, it's completely outside their paradigm: you simply touch the patient's forehead and, with a surge of energy, they're healed. You don't do it to boast, though. All you want is to help.]]></story_6>
 			<segment_names>
 				<name>Diagnose</name>
 				<name>Treat</name>
@@ -3485,6 +3490,7 @@
             <tooltip><![CDATA[
             Resets all talent levels, soulstones, imbue mind and imbue body. Other skills and buffs are unchanged.<br>
             Requires both 500 Imbue Mind and 500 Imbue Body.<br>
+            Requires surveying 100% of the zone.<br>
             Increases the exp multiplier of training actions by 100% and raises all action speeds by 50% per level.
             ]]></tooltip>
             <story_1><![CDATA[<b>Attempted soul infusion:</b>⮀ As you explore the valley-that-should-be-a-mountain, you come across an improvised-looking altar. The energy surrounding it reminds you of the altar on Mount Olympus where you awaited the judgement of the gods, but twisted like the dark energies you've felt along the Forest Path...]]></story_1>

--- a/lang/en-EN/game.xml
+++ b/lang/en-EN/game.xml
@@ -3273,8 +3273,8 @@
             <label>Open Portal</label>
             <tooltip><![CDATA[
             The Explorers' guild tells you of a secret grove within the Jungle, where the barrier between realms is weakest. With enough restoration skill, you might be able to open a rift back and leave the shadow realm. However, it seems quite a bit of time passes in the portal, and some merchants have closed up shop.<br>
-            Unlocked with 75% of the world surveyed, and 1000 Restoration.<br>
-            Travels to Forest Path.<br>Buy Mana actions can not be used for the rest of the current loop.
+            Unlocked with 75% of the world surveyed.<br>
+            Travels to Forest Path.<br>Buy Mana actions can not be used for the rest of the current loop.<br>Requires 1000 Restoration.
             ]]></tooltip>
             <story_1><![CDATA[<b>Portal opened:</b>⮀ Despite the Veil being thin in this place, you still have to push quite a bit to get through. Whether it is due to the Gods trying to keep the Shadow Realm from invading or the simple physics of inter-realm travel, you can feel the hunger from the Jungle grow quiet as you approach the rippling portal you just created and step through to the forest on the other side. Looking at the sky, you're surprised to find that night is falling now!]]></story_1>
         </open_portal>

--- a/lang/en-EN/game.xml
+++ b/lang/en-EN/game.xml
@@ -3273,8 +3273,8 @@
             <label>Open Portal</label>
             <tooltip><![CDATA[
             The Explorers' guild tells you of a secret grove within the Jungle, where the barrier between realms is weakest. With enough restoration skill, you might be able to open a rift back and leave the shadow realm. However, it seems quite a bit of time passes in the portal, and some merchants have closed up shop.<br>
-            Unlocked with 75% of the world surveyed.<br>
-            Travels to Forest Path.<br>Buy Mana actions can not be used for the rest of the current loop.<br>Requires 1000 Restoration.
+            Unlocked with 75% of the world surveyed, and 1000 Restoration.<br>
+            Travels to Forest Path.<br>Buy Mana actions can not be used for the rest of the current loop.
             ]]></tooltip>
             <story_1><![CDATA[<b>Portal opened:</b>⮀ Despite the Veil being thin in this place, you still have to push quite a bit to get through. Whether it is due to the Gods trying to keep the Shadow Realm from invading or the simple physics of inter-realm travel, you can feel the hunger from the Jungle grow quiet as you approach the rippling portal you just created and step through to the forest on the other side. Looking at the sky, you're surprised to find that night is falling now!]]></story_1>
         </open_portal>

--- a/lang/en-EN/game.xml
+++ b/lang/en-EN/game.xml
@@ -3490,7 +3490,6 @@
             <tooltip><![CDATA[
             Resets all talent levels, soulstones, imbue mind and imbue body. Other skills and buffs are unchanged.<br>
             Requires both 500 Imbue Mind and 500 Imbue Body.<br>
-            Requires surveying 100% of the zone.<br>
             Increases the exp multiplier of training actions by 100% and raises all action speeds by 50% per level.
             ]]></tooltip>
             <story_1><![CDATA[<b>Attempted soul infusion:</b>⮀ As you explore the valley-that-should-be-a-mountain, you come across an improvised-looking altar. The energy surrounding it reminds you of the altar on Mount Olympus where you awaited the judgement of the gods, but twisted like the dark energies you've felt along the Forest Path...]]></story_1>


### PR DESCRIPTION
- Tweak some actions to make things visible sooner to help the player make informed choices, or give hints about possible progression.
- Add a story for Restoration==1 on Heal the Sick to help player understand why Restoration isn't helping
- Allow player to adventure in Large Dungeon with zombies to make it a little less painful to get the 20,000 floors completed.